### PR TITLE
Fix missing version switcher

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,10 @@ theme:
     - search.suggest
     - search.highlight
 
+extra:
+  version:
+    provider: mike
+
 extra_css:
   - stylesheets/extra.css
 


### PR DESCRIPTION
Adds `extra.version.provider: mike` to mkdocs.yml, which is required by the Material theme to render the version selector dropdown in the header.