### PR TITLE
Remove Material for MkDocs footer credit

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ theme:
 extra:
   version:
     provider: mike
+  generator: false
 
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
## Summary
- Sets `generator: false` in `mkdocs.yml` to hide the "Made with Material for MkDocs" footer text.

## Test plan
- [ ] Merge and confirm footer absent on deployed site